### PR TITLE
Update doco

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-This repository is used to manage the backlog for Octopus Deploy.
-
-## Do not create issues here directly
-
-If you've found a bug or something isn't working, please get in touch with [our support team](https://octopus.com/support) instead. We don't read new GitHub issues regularly, so if you post here it will likely not get a reply. But if you contact support we can probably help to find a workaround or make sure the issue gets prioritized properly.
-
-If you have an suggestion or a feature request, please post it to [our UserVoice site](https://octopusdeploy.uservoice.com) so others can vote for it.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,9 +1,7 @@
-This repository is used to manage the backlog for Octopus Deploy. 
+This repository is used to manage the backlog for Octopus Deploy.
 
 ## Do not create issues here directly
 
-We want our backlog to reflect things we've committed to doing in the near future, and we like to keep it to below 50 items or less. 
-
-If you've found a bug or something isn't working, please get in touch with [our support team](https://octopus.com/support) instead. We don't read new GitHub issues regularly, so if you post here it will likely not get a reply. But if you contact support we can probably help to find a workaround or make sure the issue gets prioritized properly. 
+If you've found a bug or something isn't working, please get in touch with [our support team](https://octopus.com/support) instead. We don't read new GitHub issues regularly, so if you post here it will likely not get a reply. But if you contact support we can probably help to find a workaround or make sure the issue gets prioritized properly.
 
 If you have an suggestion or a feature request, please post it to [our UserVoice site](https://octopusdeploy.uservoice.com) so others can vote for it.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,6 @@
 ---
-name: Bug report from triage
-about: For the Octopus team to record a bug report which has gone through triage and
-  we have committed to implementing a bug fix
+name: Bug report
+about: For the Octopus team to record a confirmed bug report
 title: ''
 labels: kind/bug
 assignees: ''
@@ -51,7 +50,7 @@ Insert your log exerpt here.
 
 <!-- Which versions of Octopus Server, or other software are affected by this problem? A range is usually helpful if you can figure it out. -->
 
-**Octopus Server:** 
+**Octopus Server:**
 
 ## Workarounds
 

--- a/.github/ISSUE_TEMPLATE/patch-release-note.md
+++ b/.github/ISSUE_TEMPLATE/patch-release-note.md
@@ -3,7 +3,7 @@ name: Patch Release Note
 about: This issue represents the fact we have shipped a bug fix for a previous, supported
   release.
 title: "[Copy the title from the core issue describing this bug]"
-labels: kind/LTS-patch-release-note
+labels: kind/patch-release-note
 assignees: ''
 
 ---
@@ -11,13 +11,13 @@ assignees: ''
 # Tips for success
 
 - Copy the title from the "core issue" which describes the bug in more detail. This issue points to the core issue and adds a release note.
-- Assign this issue to the single milestone appropriate for the patch. If you are shipping a fix for `2019.3` in the patch `2019.3.5`, assign the issue to a milestone called `2019.3.5`.
-- Tag this issue with the single `LTS/major.minor` tag appropriate for the patch. If you are shipping a fix for `2019.3` apply the tag `LTS/2019.3`.
+- Assign this issue to the single milestone appropriate for the patch. If you are shipping a fix for `2020.2` in the patch `2020.2.5`, assign the issue to a milestone called `2020.2.5`.
+- Tag this issue with the single `release/major.minor` tag appropriate for the patch. If you are shipping a fix for `2020.2` apply the tag `release/2020.2`.
 - Add a comment with the prefix `Release Note:`. This comment will be used to build the release notes when you ship the patch.
 - Delete all this help text, and keep the templated section below.
 
 # Replace the details in this example and delete everything else including this heading
 
-#1 also affected `2019.3`. The fix has been shipped in the patch indicated by the milestone. If you are using `2019.3` we highly recommend applying this patch.
+#1 also affected `2020.2`. The fix has been shipped in the patch indicated by the milestone. If you are using `2020.2` we highly recommend applying this patch.
 
 Learn about [Releases of Octopus Deploy Server](https://g.octopushq.com/longtermsupport).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-Welcome! This is a public repository used to track issues, bugs and upcoming features for future releases of [Octopus Deploy](https://octopus.com). 
+# Octopus Deploy issues
 
-**For suggestions and feature ideas, please use [UserVoice](https://octopusdeploy.uservoice.com).** UserVoice allows items to be voted on, so it's much easier for us to track suggestions and prioritize accordingly. 
+Welcome! This is a public repository used to track issues, bugs and upcoming features for future releases of [Octopus Deploy](https://octopus.com).
+
+**For suggestions and feature ideas, please use [UserVoice](https://octopusdeploy.uservoice.com).** UserVoice allows items to be voted on, so it's much easier for us to track suggestions and prioritize accordingly.
 
 If you've encountered a problem and you need some help, please get in touch with [our support team](https://octopus.com/support). This helps us to triage issues and make sure we don't miss anything important.
+
+## Contributing
+If you are a member of the Octopus team, see the [contribution guide](docs/CONTRIBUTING.md) for information on how we use GitHub issues in this repository.

--- a/docs/CONTRIBUTING.internal.md
+++ b/docs/CONTRIBUTING.internal.md
@@ -1,0 +1,34 @@
+# How we use GitHub Issues
+
+> Note: this page is intended for Octopus team members only. If you're an Octopus user and you've found a bug or something isn't working, please get in touch with [our support team](https://octopus.com/support) instead.
+
+We use this public GitHub repository as a way to communicate with our community about what we are working on for the core Octopus product.
+
+Different teams across Octopus use the public issues in this repository for the following purposes:
+
+- **Engineers**: Use public issues for linking Pull Requests only. This helps with automatically release note generation.
+- **Support** and **Customer Success** teams:
+  - If you want someone to address an issue, you still need to bring it to the attention of the appropriate team internally, for example, via the requests channel of a Quick Reaction Force.
+  - Use public issues to aid communication with customers while waiting on a possible fix. Customers can subscribe to these GitHub issues, you can use them to collate and track relevant support tickets, and publish workarounds for multiple customers in a single place.
+- **Product** teams: Product teams own the Issues list, closing anything that's unlikely to be fixed, and providing context to Support and Customer Success teams as necessary to help manage expectations.
+
+## Which repository should I create the issue in?
+
+If you want to track an Issue that doesn't deserve public attention, track it with an Issue in the [Private GitHub repository](https://github.com/OctopusDeploy/OctopusDeploy/issues). This way we won't lose track of the item, and it won't be involved in automatic release note generation.
+
+This issues repository is for the core Octopus product.  Open-source extensions to Octopus have their own repositories, and issues for them should be managed there. For example, see the [TeamCity plugin](https://github.com/OctopusDeploy/Octopus-TeamCity) and [GitHub issue tracker](https://github.com/OctopusDeploy/GitHubIssueTracker) repositories.
+
+## How to raise an issue
+
+Make use of the issue templates and fill out all of the sections. The more specific details you can provide, the better. For example, providing links to the original reports for bugs (e.g. support tickets), details of how to replicate the issue, and known workarounds wherever possible will help affected customers, and help speed up a resolution. Remember, once you've created an issue, you still need to raise it with the relevant team internally.
+
+## How we use GitHub Milestones
+
+We use GitHub Milestones to group Issues into a Release, not so much for planning purposes. Once an Issue is closed we add it to the Milestone representing the Release that will ship the fix for the Issue. We find all of the closed Issues in a Milestone to build Release Notes.
+
+## Release Note generation
+It's important that we have good release notes with each build (we never seem to get into trouble for having too many release notes).
+
+We automatically create Release Notes in markdown by querying the public GitHub Issues that form part of a Release.
+
+We scan the Comments of an Issue for one beginning with a specific string: `Release Note: ` (or any other defined in the source) and use that for the Release Note, otherwise, we'll use the Issue Title.

--- a/docs/CONTRIBUTING.internal.md
+++ b/docs/CONTRIBUTING.internal.md
@@ -10,7 +10,7 @@ Different teams across Octopus use the public issues in this repository for the 
 - **Support** and **Customer Success** teams:
   - If you want someone to address an issue, you still need to bring it to the attention of the appropriate team internally, for example, via the requests channel of a Quick Reaction Force.
   - Use public issues to aid communication with customers while waiting on a possible fix. Customers can subscribe to these GitHub issues, you can use them to collate and track relevant support tickets, and publish workarounds for multiple customers in a single place.
-- **Product** teams: Product teams own the Issues list, closing anything that's unlikely to be fixed, and providing context to Support and Customer Success teams as necessary to help manage expectations.
+- **Product** teams: Product teams own the Issues list, they will close anything that's unlikely to be fixed and provide context to Support and Customer Success teams as necessary to help manage expectations.
 
 ## Which repository should I create the issue in?
 

--- a/docs/CONTRIBUTING.internal.md
+++ b/docs/CONTRIBUTING.internal.md
@@ -14,7 +14,7 @@ Different teams across Octopus use the public issues in this repository for the 
 
 ## Which repository should I create the issue in?
 
-If you want to track an Issue that doesn't deserve public attention, track it with an Issue in the [Private GitHub repository](https://github.com/OctopusDeploy/OctopusDeploy/issues). This way we won't lose track of the item, and it won't be involved in automatic release note generation.
+If you want to track an Issue that doesn't deserve public attention, you can track it with an Issue in the [Private GitHub repository](https://github.com/OctopusDeploy/OctopusDeploy/issues).
 
 This issues repository is for the core Octopus product.  Open-source extensions to Octopus have their own repositories, and issues for them should be managed there. For example, see the [TeamCity plugin](https://github.com/OctopusDeploy/Octopus-TeamCity) and [GitHub issue tracker](https://github.com/OctopusDeploy/GitHubIssueTracker) repositories.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing Octopus issues
+
 This repository is used by the Octopus team to communicate with our community about what we are working on for the core Octopus Server product.
 
 ## Do not create issues here directly
@@ -6,3 +8,6 @@ If you've found a bug or something isn't working, please get in touch with [our 
 
 If you have a suggestion or a feature request, please post it to [our UserVoice site](https://octopusdeploy.uservoice.com) so others can vote for it.
 
+## If you are a member of the Octopus team
+
+The Octopus team internally uses this repository as described in the [internal contribution guide](CONTRIBUTING.internal.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,8 @@ This repository is used by the Octopus team to communicate with our community ab
 
 ## Do not create issues here directly
 
-If you've found a bug or something isn't working, please get in touch with [our support team](https://octopus.com/support) instead. We don't read new GitHub issues regularly, so if you post here it will likely not get a reply. If you [contact support](https://octopus.com/support), we can probably help to find a workaround or make sure the issue gets prioritized properly.
+If you've found a bug or something isn't working, please get in touch with [our support team](https://octopus.com/support). We don't read new GitHub issues regularly, so if you post here it will likely not get a reply. If you [contact support](https://octopus.com/support), we can probably help to find a workaround or make sure the issue gets prioritized properly.
+
 
 If you have a suggestion or a feature request, please post it to [our UserVoice site](https://octopusdeploy.uservoice.com) so others can vote for it.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+This repository is used by the Octopus team to communicate with our community about what we are working on for the core Octopus Server product.
+
+## Do not create issues here directly
+
+If you've found a bug or something isn't working, please get in touch with [our support team](https://octopus.com/support) instead. We don't read new GitHub issues regularly, so if you post here it will likely not get a reply. If you [contact support](https://octopus.com/support), we can probably help to find a workaround or make sure the issue gets prioritized properly.
+
+If you have a suggestion or a feature request, please post it to [our UserVoice site](https://octopusdeploy.uservoice.com) so others can vote for it.
+


### PR DESCRIPTION
## Context
[As discussed internally](https://octopusdeploy.slack.com/archives/C015C2LBGSZ/p1592188303007700), across Octopus we have moved a lot of Confluence doco into `KonMari`, with a goal to:

> Focus on the fundamental/shared concepts [in Confluence], and delegate github repository specific things to repo docs, like CONTRIBUTING.md

## This PR

Changes in this PR:
- Moves a few sections of doco specifically related to this repo [out of Confluence](https://octopushq.atlassian.net/wiki/spaces/IN/pages/36039/Development+workflow#Developmentworkflow-HowweuseGitHubIssues) and into the `./docs` of this repo. The content of this doco was [discussed and agreed internally earlier this year](https://octopusdeploy.slack.com/archives/CATSXVA9K/p1584427376093800?thread_ts=1584427335.093200&cid=CATSXVA9K).
- Minor edits to issue templates to remove references to "LTS"
- Clarified that the creation of an issue in this repo means we have _confirmed a new bug report_, rather than necessarily committed to implementing a bug fix